### PR TITLE
Add writing-oriented titles and meta descriptions to blog pages

### DIFF
--- a/src/hooks/usePageMeta.ts
+++ b/src/hooks/usePageMeta.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+
+// Sets the document title and meta description for a page, restoring the
+// previous values when the page unmounts.
+const usePageMeta = (title: string, description?: string) => {
+  useEffect(() => {
+    const meta = document.querySelector<HTMLMetaElement>('meta[name="description"]');
+    const previousTitle = document.title;
+    const previousDescription = meta?.content;
+
+    document.title = title;
+    if (meta && description) {
+      meta.content = description;
+    }
+
+    return () => {
+      document.title = previousTitle;
+      if (meta && previousDescription !== undefined) {
+        meta.content = previousDescription;
+      }
+    };
+  }, [title, description]);
+};
+
+export default usePageMeta;

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -11,6 +11,7 @@ import {
   useColorModeValue,
 } from '@chakra-ui/react';
 import { Link as RouterLink } from 'react-router-dom';
+import usePageMeta from '../hooks/usePageMeta';
 import { articles } from '../data/articles';
 
 const formatDate = (date: string) =>
@@ -21,6 +22,10 @@ const formatDate = (date: string) =>
   });
 
 const Blog = () => {
+  usePageMeta(
+    'Cyd Villavicencio | Blog & Writing',
+    'The writing of Cyd Villavicencio: articles, essays and musings on sports, movies, tech and building things for the web.'
+  );
   const bgColor = useColorModeValue('gray.50', 'gray.900');
   const cardBg = useColorModeValue('white', 'gray.800');
   const textColor = useColorModeValue('gray.600', 'gray.300');

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -15,6 +15,7 @@ import {
 import { Fragment } from 'react';
 import { FaArrowLeft } from 'react-icons/fa';
 import { Navigate, Link as RouterLink, useParams } from 'react-router-dom';
+import usePageMeta from '../hooks/usePageMeta';
 import { articles, type ArticleBlock } from '../data/articles';
 
 const formatDate = (date: string) =>
@@ -110,9 +111,20 @@ const ArticleBlockView = ({ block }: { block: ArticleBlock }) => {
   }
 };
 
+// Clamps text to a meta-description-friendly length at a word boundary
+const clampDescription = (text: string, max = 155) => {
+  if (text.length <= max) return text;
+  const cut = text.slice(0, max);
+  return `${cut.slice(0, cut.lastIndexOf(' '))}…`;
+};
+
 const BlogPost = () => {
   const { slug } = useParams();
   const article = articles.find((a) => a.slug === slug);
+  usePageMeta(
+    article ? `${article.title} | Cyd Villavicencio` : 'Cyd Villavicencio | Blog & Writing',
+    article ? clampDescription(article.excerpt) : undefined
+  );
   const metaColor = useColorModeValue('gray.500', 'gray.400');
   const subtitleColor = useColorModeValue('gray.600', 'gray.300');
 


### PR DESCRIPTION
## Summary

Follow-up to #6. The blog pages previously inherited the site-wide developer-oriented `<title>` and meta description from `index.html`. This gives them their own, oriented around the writing:

- **`src/hooks/usePageMeta.ts`** (new): small hook that sets `document.title` and the `meta[name="description"]` content on mount and restores the previous values on unmount, so non-blog pages keep the site defaults
- **Blog index** (`/blog`): title `Cyd Villavicencio | Blog & Writing` with a writing-focused description
- **Article pages** (`/blog/:slug`): title `<Article Title> | Cyd Villavicencio`, description taken from the article's excerpt, clamped to ~155 characters at a word boundary

No new dependencies.

## Testing

- `npm run build` passes (TypeScript strict mode)
- Verified in a headless browser against the production build: blog index and article pages show their own title/description, and navigating back to Home restores the site defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YJmUS4dcSiarN71iYTBtJ

---
_Generated by [Claude Code](https://claude.ai/code/session_019YJmUS4dcSiarN71iYTBtJ)_